### PR TITLE
Gracefully handle errors when matching WordCamp posts to sites.

### DIFF
--- a/customize.php
+++ b/customize.php
@@ -47,11 +47,18 @@ class WordCamp_StyleImport_Customize {
 
 			<div class="theme-browser">
 			<?php while ( $wordcamps->have_posts() ): $wordcamps->the_post(); ?>
-
-				<div class="theme">
 					<?php
 						$url = parse_url( 'http://' . trailingslashit( get_post_meta( get_the_ID(), 'URL', true ) ) );
-						$blog_details = get_blog_details( array( 'domain' => $url['host'], 'path' => $url['path'] ), true );
+						$blog_details = false;
+
+						if ( isset( $url['host'] ) && isset( $url['path'] ) ) {
+							$blog_details = get_blog_details( array( 'domain' => $url['host'], 'path' => $url['path'] ), true );
+						}
+
+						if ( ! $blog_details ) {
+							continue;
+						}
+
 						$theme = $wpdb->get_var(
 							$sql = sprintf( "SELECT option_value FROM %s%d_options WHERE option_name = 'stylesheet';",
 								$wpdb->base_prefix,
@@ -78,6 +85,7 @@ class WordCamp_StyleImport_Customize {
 						), $mshots );
 					?>
 
+				<div class="theme">
 					<div class="theme-screenshot">
 						<img src="<?php echo $mshots; ?>" />
 					</div>

--- a/customize.php
+++ b/customize.php
@@ -47,43 +47,43 @@ class WordCamp_StyleImport_Customize {
 
 			<div class="theme-browser">
 			<?php while ( $wordcamps->have_posts() ): $wordcamps->the_post(); ?>
-					<?php
-						$url = parse_url( 'http://' . trailingslashit( get_post_meta( get_the_ID(), 'URL', true ) ) );
-						$blog_details = false;
+				<?php
+					$url = parse_url( 'http://' . trailingslashit( get_post_meta( get_the_ID(), 'URL', true ) ) );
+					$blog_details = false;
 
-						if ( isset( $url['host'] ) && isset( $url['path'] ) ) {
-							$blog_details = get_blog_details( array( 'domain' => $url['host'], 'path' => $url['path'] ), true );
-						}
+					if ( isset( $url['host'] ) && isset( $url['path'] ) ) {
+						$blog_details = get_blog_details( array( 'domain' => $url['host'], 'path' => $url['path'] ), true );
+					}
 
-						if ( ! $blog_details ) {
-							continue;
-						}
+					if ( ! $blog_details ) {
+						continue;
+					}
 
-						$theme = $wpdb->get_var(
-							$sql = sprintf( "SELECT option_value FROM %s%d_options WHERE option_name = 'stylesheet';",
-								$wpdb->base_prefix,
-								$blog_details->blog_id
-							)
-						);
+					$theme = $wpdb->get_var(
+						$sql = sprintf( "SELECT option_value FROM %s%d_options WHERE option_name = 'stylesheet';",
+							$wpdb->base_prefix,
+							$blog_details->blog_id
+						)
+					);
 
-						$import_url = add_query_arg( array(
-							'page'        => 'editcss',
-							'source-site' => $blog_details->blog_id,
-						), $theme_url );
+					$import_url = add_query_arg( array(
+						'page'        => 'editcss',
+						'source-site' => $blog_details->blog_id,
+					), $theme_url );
 
-						$preview_url = add_query_arg( array(
-							'url'         => $home_url,
-							'source-site' => $blog_details->blog_id,
-							'theme'       => $theme,
-						), $customize_url );
+					$preview_url = add_query_arg( array(
+						'url'         => $home_url,
+						'source-site' => $blog_details->blog_id,
+						'theme'       => $theme,
+					), $customize_url );
 
-						$mshots = "http://s.wordpress.com/mshots/v1/";
-						$mshots .= urlencode( 'http://'. str_replace('.dev','.org', get_post_meta( get_the_ID(), 'URL', true ) ) );
-						$mshots = add_query_arg( array(
-							'w' => 375,
-							'h' => 250,
-						), $mshots );
-					?>
+					$mshots = "http://s.wordpress.com/mshots/v1/";
+					$mshots .= urlencode( 'http://'. str_replace('.dev','.org', get_post_meta( get_the_ID(), 'URL', true ) ) );
+					$mshots = add_query_arg( array(
+						'w' => 375,
+						'h' => 250,
+					), $mshots );
+				?>
 
 				<div class="theme">
 					<div class="theme-screenshot">


### PR DESCRIPTION
The URL field could be empty, or http://, or some other invalid string; it could also fail to match an existing site.

In either of those cases, we should just skip it.
